### PR TITLE
Add documentation, static file assistance, for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 * Install requirements via [composer](https://github.com/composer/composer) and `composer.json`
 * Migrate database via [phinx](https://github.com/robmorgan/phinx) and `phinx.yml`
-* Run application locally via `php -S localhost:8000 -t . index.php`
+* Run this Slim-based application locally via `php -S localhost:8000 -t . index.php`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# HelpMeAbstract.com
+
+## Local Development
+
+* Install requirements via [composer](https://github.com/composer/composer) and `composer.json`
+* Migrate database via [phinx](https://github.com/robmorgan/phinx) and `phinx.yml`
+* Run application locally via `php -S localhost:8000 -t . index.php`

--- a/index.php
+++ b/index.php
@@ -10,6 +10,15 @@ use GuzzleHttp\Client;
 use Spot\Config;
 use Spot\Locator;
 
+// Decline static file requests back to the PHP built-in webserver
+if (php_sapi_name() === 'cli-server') {
+    $path = realpath(__DIR__ . parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
+    if (__FILE__ !== $path && is_file($path)) {
+        return false;
+    }
+    unset($path);
+}
+
 require_once(__DIR__ . '/vendor/autoload.php');
 Dotenv::load(__DIR__);
 


### PR DESCRIPTION
The additions to `index.php` are directly from [zend](https://github.com/zendframework/ZendSkeletonApplication/blob/master/public/index.php#L9), via the super helpful @dshafik

I've also added an extremely basic README with notes about how you need to install requirements and migrate databases before running locally via the magic that is `php -S`.
