### PR TITLE
Add twitter_username to migrations

### DIFF
--- a/migrations/20150325202941_create_volunteer_table.php
+++ b/migrations/20150325202941_create_volunteer_table.php
@@ -24,6 +24,7 @@ class CreateVolunteerTable extends AbstractMigration
             ->addColumn('github_username', 'string', array('limit' => 100))
             ->addColumn('profile_image', 'string', array('limit' => 100))
             ->addColumn('profile_url', 'string', array('limit' => 100))
+            ->addColumn('twitter_username', 'string', array('limit' => 100))
             ->create();
     }
 }


### PR DESCRIPTION
`twitter_username` is used in the volunteer signup form, but doesn't exist in the phinx migrations, so I was getting errors when trying to run this locally. 

Ideally this should actually be in it's own migration file, but phinx wouldn't let me use code pretty much lifted from the documentation to update an existing table, so I added it directly to the original create-table.
