### PR TITLE
Automatically copy the .env.changeme file to .env on composer install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ If you'd like to volunteer you can sign up [here](https://helpmeabstract.com/vol
 * Migrate database via [phinx](https://github.com/robmorgan/phinx) and `phinx.yml`
    * Edit `phinx.yml` and update the database settings in the `development` setting
    * Run `php vendor/bin/phinx migrate` 
-* Copy `env.changeme` to `.env` and modify the database credentials
+* Copy `env.changeme` to `.env` (if it doesn't yet exist) and modify the database credentials
 * Run this Slim-based application locally via `php -S localhost:8000 -t . index.php` from the `public/` folder

--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
   "autoload": {
     "psr-4": { "HelpMeAbstract\\": "src/" }
   },
-  "minimum-stability": "stable"
+  "minimum-stability": "stable",
+  "scripts": {
+    "post-install-cmd": [
+        "@php -r \"file_exists('.env') || copy('.env.changeme', '.env');\""
+    ]
+  }
 }


### PR DESCRIPTION
This PR adds a "post-install-cmd" script to the `composer.json` to automatically copy `.env.changeme` to `.env`, saving users a step as they set up a development environment.