### PR TITLE
Update copyright date to use current year.

### DIFF
--- a/views/includes/footer.php
+++ b/views/includes/footer.php
@@ -1,7 +1,7 @@
 <footer id="footer" class="container">
     <div id="copyright">
         <ul class="menu">
-            <li>&copy; 2015 - 2018 HelpMeAbstract. All rights reserved</li>
+            <li>&copy; 2015 - {{ "now"|date('Y') }} HelpMeAbstract. All rights reserved</li>
             <li> Built with ♥️ in Brooklyn</li>
             <li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
             <li><a href="https://github.com/helpmeabstract/helpmeabstract">Improve this website</a></li>


### PR DESCRIPTION
I was not sure if HelpMeAbstract was still active...

This is a simple change to use the current year via twig for the copyright in the footer.